### PR TITLE
Command pattern for applying discounts

### DIFF
--- a/DesignPatternsWorkshop.Application/Commands/AddProductCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/AddProductCommand.cs
@@ -1,0 +1,31 @@
+﻿using DesignPatternsWorkshop.Domain.Models;
+
+namespace DesignPatternsWorkshop.Application.Commands;
+
+public class AddProductCommand : IPurchaseCommand
+{
+    #region properties
+    private readonly Purchase _purchase;
+    private readonly Product _product;
+    #endregion
+
+    #region constructor
+    public AddProductCommand(Purchase purchase, Product product)
+    {
+        _purchase = purchase;
+        _product = product;
+    }
+    #endregion
+
+    #region methods
+    public void Execute()
+    {
+        _purchase.Products.Add(_product);
+    }
+
+    public void Undo()
+    {
+        _purchase.Products.Remove(_product);
+    }
+    #endregion
+}

--- a/DesignPatternsWorkshop.Application/Commands/AddProductCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/AddProductCommand.cs
@@ -23,7 +23,7 @@ public class AddProductCommand : IPurchaseCommand
         _purchase.Products.Add(_product);
     }
 
-    public void Undo()
+    public void Revert()
     {
         _purchase.Products.Remove(_product);
     }

--- a/DesignPatternsWorkshop.Application/Commands/AddProductCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/AddProductCommand.cs
@@ -2,30 +2,9 @@
 
 namespace DesignPatternsWorkshop.Application.Commands;
 
-public class AddProductCommand : IPurchaseCommand
+public record AddProductCommand(Purchase purchase, Product product) : IPurchaseCommand
 {
-    #region properties
-    private readonly Purchase _purchase;
-    private readonly Product _product;
-    #endregion
+    public void Execute() => purchase.Products.Add(product);
 
-    #region constructor
-    public AddProductCommand(Purchase purchase, Product product)
-    {
-        _purchase = purchase;
-        _product = product;
-    }
-    #endregion
-
-    #region methods
-    public void Execute()
-    {
-        _purchase.Products.Add(_product);
-    }
-
-    public void Revert()
-    {
-        _purchase.Products.Remove(_product);
-    }
-    #endregion
+    public void Revert() => purchase.Products.Remove(product);
 }

--- a/DesignPatternsWorkshop.Application/Commands/IPurchaseCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/IPurchaseCommand.cs
@@ -1,0 +1,13 @@
+﻿namespace DesignPatternsWorkshop.Application.Commands;
+
+public interface IPurchaseCommand
+{
+    /// <summary>
+    /// Applies the command to the given transaction, leaving it in the Undo stack for later action.
+    /// </summary>
+    public void Execute();
+    /// <summary>
+    /// Removes the command from the transation, leaving it in the Redo stack for later action.
+    /// </summary>
+    public void Undo();
+}

--- a/DesignPatternsWorkshop.Application/Commands/IPurchaseCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/IPurchaseCommand.cs
@@ -3,11 +3,11 @@
 public interface IPurchaseCommand
 {
     /// <summary>
-    /// Applies the command to the given transaction, leaving it in the Undo stack for later action.
+    /// Applies the effects of the command.
     /// </summary>
     public void Execute();
     /// <summary>
-    /// Removes the command from the transation, leaving it in the Redo stack for later action.
+    /// Reverts the effects of the command.
     /// </summary>
-    public void Undo();
+    public void Revert();
 }

--- a/DesignPatternsWorkshop.Application/Commands/RemoveProductCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/RemoveProductCommand.cs
@@ -23,7 +23,7 @@ public class RemoveProductCommand : IPurchaseCommand
         _purchase.Products.Remove(_product);
     }
 
-    public void Undo()
+    public void Revert()
     {
         _purchase.Products.Add(_product);
     }

--- a/DesignPatternsWorkshop.Application/Commands/RemoveProductCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/RemoveProductCommand.cs
@@ -1,0 +1,31 @@
+﻿using DesignPatternsWorkshop.Domain.Models;
+
+namespace DesignPatternsWorkshop.Application.Commands;
+
+public class RemoveProductCommand : IPurchaseCommand
+{
+    #region properties
+    private readonly Purchase _purchase;
+    private readonly Product _product;
+    #endregion
+
+    #region constructor
+    public RemoveProductCommand(Purchase purchase, Product product)
+    {
+        _purchase = purchase;
+        _product = product;
+    }
+    #endregion
+
+    #region methods
+    public void Execute()
+    {
+        _purchase.Products.Remove(_product);
+    }
+
+    public void Undo()
+    {
+        _purchase.Products.Add(_product);
+    }
+    #endregion
+}

--- a/DesignPatternsWorkshop.Application/Commands/RemoveProductCommand.cs
+++ b/DesignPatternsWorkshop.Application/Commands/RemoveProductCommand.cs
@@ -2,30 +2,9 @@
 
 namespace DesignPatternsWorkshop.Application.Commands;
 
-public class RemoveProductCommand : IPurchaseCommand
+public record RemoveProductCommand(Purchase purchase, Product product) : IPurchaseCommand
 {
-    #region properties
-    private readonly Purchase _purchase;
-    private readonly Product _product;
-    #endregion
+    public void Execute() => purchase.Products.Remove(product);
 
-    #region constructor
-    public RemoveProductCommand(Purchase purchase, Product product)
-    {
-        _purchase = purchase;
-        _product = product;
-    }
-    #endregion
-
-    #region methods
-    public void Execute()
-    {
-        _purchase.Products.Remove(_product);
-    }
-
-    public void Revert()
-    {
-        _purchase.Products.Add(_product);
-    }
-    #endregion
+    public void Revert() => purchase.Products.Add(product);
 }

--- a/DesignPatternsWorkshop.Domain/Models/Purchase.cs
+++ b/DesignPatternsWorkshop.Domain/Models/Purchase.cs
@@ -3,7 +3,7 @@ using DesignPatternsWorkshop.Domain.Strategies;
 
 namespace DesignPatternsWorkshop.Domain.Models;
 
-public class Transaction
+public class Purchase
 {
     #region properties
     private IDiscountStrategy _discount;
@@ -12,7 +12,7 @@ public class Transaction
     #endregion
 
     #region constructor
-    public Transaction()
+    public Purchase()
     {
         _discount = new NoDiscountStrategy();
     }

--- a/DesignPatternsWorkshop.Infrastructure/Commands/PurchaseInvoker.cs
+++ b/DesignPatternsWorkshop.Infrastructure/Commands/PurchaseInvoker.cs
@@ -1,0 +1,47 @@
+﻿using DesignPatternsWorkshop.Application.Commands;
+
+namespace DesignPatternsWorkshop.Infrastructure.Commands;
+
+public class PurchaseInvoker
+{
+    #region properties
+    private readonly Stack<IPurchaseCommand> _undoStack = new();
+    private readonly Stack<IPurchaseCommand> _redoStack = new();
+    #endregion
+
+    #region methods
+    /// <summary>
+    /// Executes a given Purchase Command and clears the Redo Stack.
+    /// </summary>
+    /// <param name="command"></param>
+    public void ExecuteCommand(IPurchaseCommand command)
+    {
+        _undoStack.Push(command);
+        _redoStack.Clear();
+    }
+
+    /// <summary>
+    /// Calls the Undo method of the last command in the Undo Stack and moves it to the Redo Stack.
+    /// </summary>
+    public void Undo()
+    {
+        if(_undoStack.Count == 0) return;
+
+        var command = _undoStack.Pop();
+        command.Undo();
+        _redoStack.Push(command);
+    }
+
+    /// <summary>
+    /// Executes the latest command in the Redo Stack and moves it to the Undo Stack.
+    /// </summary>
+    public void Redo()
+    {
+        if (_redoStack.Count == 0) return;
+
+        var command = _redoStack.Pop();
+        command.Execute();
+        _undoStack.Push(command);
+    }
+    #endregion
+}

--- a/DesignPatternsWorkshop.Infrastructure/Commands/PurchaseInvoker.cs
+++ b/DesignPatternsWorkshop.Infrastructure/Commands/PurchaseInvoker.cs
@@ -16,6 +16,7 @@ public class PurchaseInvoker
     /// <param name="command"></param>
     public void ExecuteCommand(IPurchaseCommand command)
     {
+        command.Execute();
         _undoStack.Push(command);
         _redoStack.Clear();
     }

--- a/DesignPatternsWorkshop.Infrastructure/Commands/PurchaseInvoker.cs
+++ b/DesignPatternsWorkshop.Infrastructure/Commands/PurchaseInvoker.cs
@@ -28,7 +28,7 @@ public class PurchaseInvoker
         if(_undoStack.Count == 0) return;
 
         var command = _undoStack.Pop();
-        command.Undo();
+        command.Revert();
         _redoStack.Push(command);
     }
 


### PR DESCRIPTION
Defines the command interface and two use cases to add and to remove products from a purchase

Renamed `Transaction` model as `Purchase` to avoid conflicts with the native System namespace.